### PR TITLE
fix: impossible to select curves on dense graphs

### DIFF
--- a/visplot.py
+++ b/visplot.py
@@ -184,7 +184,7 @@ class plot:
         # XXX: cons: behaviour changes depending on the window size
         ratio = 20
         camera_state = self.view.camera.get_state()["rect"]
-        bounding_x = camera_state.width / ratio
+        bounding_x = max(1., camera_state.width / ratio)
         bounding_y = camera_state.height / ratio
 
         tr = self.canvas.scene.node_transform(self.view.scene)


### PR DESCRIPTION
Having bounding_x < 1. makes closest line search fail (there's no other point to compare in this case). The fix simply makes sure there's at least one point on left and right side of selection to compute distance with.

Thanks @NicsTr for finding this problem and providing an example.